### PR TITLE
Remove preferredStatusBarStyle

### DIFF
--- a/QBImagePicker/QBImagePickerController.h
+++ b/QBImagePicker/QBImagePickerController.h
@@ -52,7 +52,6 @@ typedef NS_ENUM(NSUInteger, QBImagePickerMediaType) {
 
 @property (nonatomic, assign) BOOL shouldAutorotate;
 @property (nonatomic, assign) UIInterfaceOrientationMask supportedInterfaceOrientations;
-@property (nonatomic, assign) UIStatusBarStyle preferredStatusBarStyle;
 @property (nonatomic) UIView *authorizationView;
 
 @end


### PR DESCRIPTION
It created warnings when building with carthage, also it's not required since it's inherited from `UIViewController`
```
*** Building scheme "QBImagePicker" in QBImagePicker.xcodeproj
QBImagePicker/QBImagePicker/QBImagePickerController.h:55:48: warning: auto property synthesis will not synthesize property 'preferredStatusBarStyle' because it is 'readwrite' but it will be synthesized 'readonly' via another property [-Wobjc-property-synthesis]
QBImagePicker/QBImagePicker/QBImagePickerController.h:55:48: warning: auto property synthesis will not synthesize property 'preferredStatusBarStyle' because it is 'readwrite' but it will be synthesized 'readonly' via another property [-Wobjc-property-synthesis]
QBImagePicker/QBImagePicker/QBImagePickerController.h:55:48: warning: auto property synthesis will not synthesize property 'preferredStatusBarStyle' because it is 'readwrite' but it will be synthesized 'readonly' via another property [-Wobjc-property-synthesis]
QBImagePicker/QBImagePicker/QBImagePickerController.h:55:48: warning: auto property synthesis will not synthesize property 'preferredStatusBarStyle' because it is 'readwrite' but it will be synthesized 'readonly' via another property [-Wobjc-property-synthesis]
```